### PR TITLE
update Rakefile so that `rake` runs tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList['test/**/test_*.rb']
 end
 
 task :default => :test


### PR DESCRIPTION
Previously, the file pattern was not matching the test files so nothing
was being loaded or run. The alternative would be to rename the test
files.